### PR TITLE
refactor(client): consolidate vocabulary, row writes, and commit transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ lib/
 
 # Local agent scaffolding — measuring tools live on the box, never in the repo.
 scripts/token-survey.mjs
+
+# Context-Governor measuring tools live on the box, never in the repo.
+context-governor/
+.context/
+CONTEXT.md

--- a/src/client/CapabilitiesSection.tsx
+++ b/src/client/CapabilitiesSection.tsx
@@ -14,9 +14,9 @@ import type {
   CapabilitiesController, CapabilitiesState, CapabilityRowView, ReasoningEffortsValue,
 } from './store.ts'
 import { messageOf, validInputModalities, validReasoningEfforts } from './store.ts'
-import type { CapabilityPatch, CapabilityState } from './writes.ts'
-import { declaredEditOps, stagedDiffers } from './writes.ts'
-import { CAPACITY_HINT, formatCapacity, parseCapacity, validCapacity } from './capacity.ts'
+import type { CapabilityPatch } from './writes.ts'
+import { declaredEditOps, patchOf, RowDraft, rowStateOf, stagedDiffers } from './writes.ts'
+import { CAPACITY_HINT, formatCapacity, validCapacity } from './capacity.ts'
 import { HarnessRpcError } from './types.ts'
 import type { CapsKey } from './locales.ts'
 
@@ -318,57 +318,6 @@ function CapacityEditor(props: {
 /* Model row                                                           */
 /* ================================================================== */
 
-/** Staged partial state of one row: null means untouched. */
-interface RowDraft {
-  /** The row edited reasoning (`undefined` staged means "inherit"). */
-  reasoningTouched: boolean
-  /** Staged reasoning-effort declaration. */
-  reasoning?: ReasoningEffortsValue | undefined
-  /** The row edited input (`undefined` staged means "inherit"). */
-  inputTouched: boolean
-  /** Staged input modalities. */
-  input?: readonly unknown[] | undefined
-  /** The row edited either capacity field (blank text means "inherit"). */
-  capacityTouched: boolean
-  /** Staged `contextWindow` text (K/M spellings; parsed on use). */
-  contextWindowText: string
-  /** Staged `maxTokens` text (K/M spellings; parsed on use). */
-  maxTokensText: string
-}
-
-/** Build the row's whole state: stored entry overlaid with the draft. */
-function rowStateOf(entry: Record<string, unknown>, draft: RowDraft | null): CapabilityState {
-  return {
-    reasoning: draft?.reasoningTouched === true
-      ? draft.reasoning
-      : entry['reasoningEfforts'] as ReasoningEffortsValue,
-    input: draft?.inputTouched === true
-      ? draft.input
-      : entry['input'] as readonly unknown[] | undefined,
-    // Capacities stage as text (a half-typed "38" is a draft too) and parse at
-    // the leaf: an unreadable spelling parses to NaN, differs from anything
-    // stored, and is refused by the apply-time validation below.
-    contextWindow: draft?.capacityTouched === true
-      ? parseCapacity(draft.contextWindowText)
-      : entry['contextWindow'] as number | undefined,
-    maxTokens: draft?.capacityTouched === true
-      ? parseCapacity(draft.maxTokensText)
-      : entry['maxTokens'] as number | undefined,
-  }
-}
-
-/** Convert the row's touched flags into a patch that preserves inheritance. */
-function patchOf(state: CapabilityState, draft: RowDraft): CapabilityPatch {
-  const patch: CapabilityPatch = {}
-  if (draft.reasoningTouched) patch.reasoning = { value: state.reasoning }
-  if (draft.inputTouched) patch.input = { value: state.input }
-  if (draft.capacityTouched) {
-    patch.contextWindow = { value: state.contextWindow }
-    patch.maxTokens = { value: state.maxTokens }
-  }
-  return patch
-}
-
 /** One model row: header, disclosure with both editors, and its save traffic. */
 function ModelRow(props: {
   /** The stored entry the stage overlays (`{}` without declaration). */
@@ -385,14 +334,12 @@ function ModelRow(props: {
   levels: readonly string[]
   /** Schema-derived request modalities, or none. */
   modalities: readonly string[]
-  /** Apply traffic from the card: stage → write + reload. */
-  applyRow: (index: number, patch: CapabilityPatch) => Promise<void>
-  /** Reload authoritative state (also invoked by this row after a rejected write). */
-  controllerReload: () => Promise<void>
+  /** Apply traffic from the row: stage → commit; reload stays in commit. */
+  applyRow: (index: number, patch: CapabilityPatch) => Promise<boolean>
   /** Bound translate. */
   t: TFn
 }): ReactElement {
-  const { entry, modelId, displayName, index, writable, levels, modalities, applyRow, controllerReload, t } = props
+  const { entry, modelId, displayName, index, writable, levels, modalities, applyRow, t } = props
   const [open, setOpen] = useState(false)
   const [draft, setDraft] = useState<RowDraft | null>(null)
   const [busy, setBusy] = useState(false)
@@ -427,14 +374,11 @@ function ModelRow(props: {
     try {
       // The action is rendered only while a draft exists; keeping this path
       // total avoids a second async state machine for an impossible event.
-      await applyRow(index, patchOf(state, draft!))
-      setDraft(null)
+      const wrote = await applyRow(index, patchOf(state, draft!))
+      if (wrote) setDraft(null)
     } catch (caught: unknown) {
       setError(writeErrorText(caught, t))
-      // A failed write (incl. settings-conflict) keeps the draft here but
-      // re-anchors every sibling surface on the newest accepted state.
-      // reload() never rejects: runLoad() digests its own failures.
-      void controllerReload()
+      // commit() already reloads on failure to re-anchor every sibling surface.
     } finally {
       setBusy(false)
     }
@@ -539,8 +483,6 @@ function ModelRow(props: {
 function ProviderCard(props: {
   /** Joined row: route facts + profile models. */
   row: CapabilityRowView
-  /** The loaded namespace rows were joined from (rows render iff it exists). */
-  namespace: import('./types.ts').SettingsNamespaceView
   /** The page controller. */
   controller: CapabilitiesController
   /** Schema vocabularies. */
@@ -552,15 +494,15 @@ function ProviderCard(props: {
   /** Bound translate. */
   t: TFn
 }): ReactElement {
-  const { row, namespace, controller, levels, modalities, writable, t } = props
+  const { row, controller, levels, modalities, writable, t } = props
   const applyRow = useCallback(async (
     index: number,
     patch: CapabilityPatch,
-  ): Promise<void> => {
-    await controller.mutate(declaredEditOps(namespace, row.entry.settingsPath, index, patch))
-    await controller.reload()
-  }, [controller, namespace, row.entry.settingsPath])
-  const controllerReload = useCallback(() => controller.reload(), [controller])
+  ): Promise<boolean> => {
+    // commit() builds from the same authoritative snapshot that supplies
+    // expectedRevision, writes, and owns the success/failure reload.
+    return controller.commit(snapshot => declaredEditOps(snapshot, row.entry.settingsPath, index, patch))
+  }, [controller, row.entry.settingsPath])
   const rowWritable = writable && (row.entry.declared !== true || row.declaredEditable)
   return (
     <section className="bmp-card">
@@ -588,7 +530,7 @@ function ProviderCard(props: {
               levels={levels}
               modalities={modalities}
               applyRow={applyRow}
-              controllerReload={controllerReload}
+              
               t={t}
             />
           )
@@ -640,7 +582,6 @@ export function CapabilitiesSection(props: CapabilitiesSectionProps): ReactEleme
         <ProviderCard
           key={row.entry.provider}
           row={row}
-          namespace={namespace}
           controller={controller}
           levels={snapshot.levels}
           modalities={snapshot.modalities}

--- a/src/client/CapabilitiesSection.tsx
+++ b/src/client/CapabilitiesSection.tsx
@@ -14,9 +14,9 @@ import type {
   CapabilitiesController, CapabilitiesState, CapabilityRowView, ReasoningEffortsValue,
 } from './store.ts'
 import { messageOf, validInputModalities, validReasoningEfforts } from './store.ts'
-import type { CapabilityPatch } from './writes.ts'
-import { declaredEditOps, patchOf, RowDraft, rowStateOf, stagedDiffers } from './writes.ts'
-import { CAPACITY_HINT, formatCapacity, validCapacity } from './capacity.ts'
+import type { CapabilityPatch, CapabilityState } from './writes.ts'
+import { declaredEditOps, stagedDiffers } from './writes.ts'
+import { CAPACITY_HINT, formatCapacity, parseCapacity, validCapacity } from './capacity.ts'
 import { HarnessRpcError } from './types.ts'
 import type { CapsKey } from './locales.ts'
 
@@ -317,6 +317,57 @@ function CapacityEditor(props: {
 /* ================================================================== */
 /* Model row                                                           */
 /* ================================================================== */
+
+/** Staged partial state of one row: null means untouched. */
+interface RowDraft {
+  /** The row edited reasoning (`undefined` staged means "inherit"). */
+  reasoningTouched: boolean
+  /** Staged reasoning-effort declaration. */
+  reasoning?: ReasoningEffortsValue | undefined
+  /** The row edited input (`undefined` staged means "inherit"). */
+  inputTouched: boolean
+  /** Staged input modalities. */
+  input?: readonly unknown[] | undefined
+  /** The row edited either capacity field (blank text means "inherit"). */
+  capacityTouched: boolean
+  /** Staged `contextWindow` text (K/M spellings; parsed on use). */
+  contextWindowText: string
+  /** Staged `maxTokens` text (K/M spellings; parsed on use). */
+  maxTokensText: string
+}
+
+/** Build the row's whole state: stored entry overlaid with the draft. */
+function rowStateOf(entry: Record<string, unknown>, draft: RowDraft | null): CapabilityState {
+  return {
+    reasoning: draft?.reasoningTouched === true
+      ? draft.reasoning
+      : entry['reasoningEfforts'] as ReasoningEffortsValue,
+    input: draft?.inputTouched === true
+      ? draft.input
+      : entry['input'] as readonly unknown[] | undefined,
+    // Capacities stage as text (a half-typed "38" is a draft too) and parse at
+    // the leaf: an unreadable spelling parses to NaN, differs from anything
+    // stored, and is refused by the apply-time validation below.
+    contextWindow: draft?.capacityTouched === true
+      ? parseCapacity(draft.contextWindowText)
+      : entry['contextWindow'] as number | undefined,
+    maxTokens: draft?.capacityTouched === true
+      ? parseCapacity(draft.maxTokensText)
+      : entry['maxTokens'] as number | undefined,
+  }
+}
+
+/** Convert the row's touched flags into a patch that preserves inheritance. */
+function patchOf(state: CapabilityState, draft: RowDraft): CapabilityPatch {
+  const patch: CapabilityPatch = {}
+  if (draft.reasoningTouched) patch.reasoning = { value: state.reasoning }
+  if (draft.inputTouched) patch.input = { value: state.input }
+  if (draft.capacityTouched) {
+    patch.contextWindow = { value: state.contextWindow }
+    patch.maxTokens = { value: state.maxTokens }
+  }
+  return patch
+}
 
 /** One model row: header, disclosure with both editors, and its save traffic. */
 function ModelRow(props: {

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -55,47 +55,46 @@ export function messageOf(error: unknown): string {
 }
 
 /**
- * The reasoning-effort levels a model entry may declare, read out of the
- * owning namespace's own serialized schema so the page's vocabulary cannot
- * drift from the adapter's: the `models` item's `reasoningEfforts` field is
- * a union of `false` and a dict whose key union lists the levels (empty
- * list when the schema declares none).
+ * Extract both capability vocabularies from one rehydrated schema walk.
+ *
+ * The reasoning and input vocabularies are not two independent parsing paths:
+ * they both begin at the same `models` entry node inside the owning namespace.
+ * Extracting them together keeps one conceptual schema-to-vocabulary operation
+ * and avoids rehydrating/parsing the schema twice per load.
  */
-export function reasoningLevelChoices(namespace: SettingsNamespaceView | undefined): string[] {
-  if (namespace === undefined) return []
+export function extractCapabilityVocabulary(
+  namespace: SettingsNamespaceView | undefined,
+): { levels: string[]; modalities: string[] } {
+  const empty: { levels: string[]; modalities: string[] } = { levels: [], modalities: [] }
+  if (namespace === undefined) return empty
   const models = nodeAtPath(rehydrateSchema(namespace.schema), ['providers', PROBE_ROUTE, 'models']) as
     | { type?: string; inner?: unknown }
     | undefined
-  if (models?.type !== 'array' || models.inner === undefined) return []
+  if (models?.type !== 'array' || models.inner === undefined) return empty
   const entry = models.inner as { type?: string; dict?: Record<string, unknown> } | undefined
-  if (entry?.type !== 'object' || entry.dict === undefined) return []
-  const efforts = entry.dict['reasoningEfforts'] as { type?: string; list?: readonly unknown[] } | undefined
-  if (efforts?.type !== 'union' || efforts.list === undefined) return []
-  const dict = efforts.list.find(member => (member as { type?: string }).type === 'dict') as
-    | { sKey?: { type?: string; list?: readonly { value?: unknown }[] } }
-    | undefined
-  if (dict?.sKey?.type !== 'union' || dict.sKey.list === undefined) return []
-  return dict.sKey.list.map(member => member.value).filter((value): value is string => typeof value === 'string')
-}
+  if (entry?.type !== 'object' || entry.dict === undefined) return empty
 
-/**
- * The request modalities a model entry may declare, read out of the same
- * schema: the `models` item's `input` field is an array of a const union
- * (empty list when the schema declares none).
- */
-export function inputModalityChoices(namespace: SettingsNamespaceView | undefined): string[] {
-  if (namespace === undefined) return []
-  const models = nodeAtPath(rehydrateSchema(namespace.schema), ['providers', PROBE_ROUTE, 'models']) as
-    | { type?: string; inner?: unknown }
-    | undefined
-  if (models?.type !== 'array' || models.inner === undefined) return []
-  const entry = models.inner as { type?: string; dict?: Record<string, unknown> } | undefined
-  if (entry?.type !== 'object' || entry.dict === undefined) return []
+  const levels: string[] = []
+  const efforts = entry.dict['reasoningEfforts'] as { type?: string; list?: readonly unknown[] } | undefined
+  if (efforts?.type === 'union' && efforts.list !== undefined) {
+    const dict = efforts.list.find(member => (member as { type?: string }).type === 'dict') as
+      | { sKey?: { type?: string; list?: readonly { value?: unknown }[] } }
+      | undefined
+    if (dict?.sKey?.type === 'union' && dict.sKey.list !== undefined) {
+      levels.push(...dict.sKey.list.map(member => member.value).filter((value): value is string => typeof value === 'string'))
+    }
+  }
+
+  const modalities: string[] = []
   const input = entry.dict['input'] as { type?: string; inner?: unknown } | undefined
-  if (input?.type !== 'array' || input.inner === undefined) return []
-  const union = input.inner as { type?: string; list?: readonly { value?: unknown }[] } | undefined
-  if (union?.type !== 'union' || union.list === undefined) return []
-  return union.list.map(member => member.value).filter((value): value is string => typeof value === 'string')
+  if (input?.type === 'array' && input.inner !== undefined) {
+    const union = input.inner as { type?: string; list?: readonly { value?: unknown }[] } | undefined
+    if (union?.type === 'union' && union.list !== undefined) {
+      modalities.push(...union.list.map(member => member.value).filter((value): value is string => typeof value === 'string'))
+    }
+  }
+
+  return { levels, modalities }
 }
 
 /**
@@ -162,6 +161,14 @@ export function profileModels(
     typeof entry === 'object' && entry !== null && !Array.isArray(entry)
       ? entry as Record<string, unknown>
       : {})
+}
+
+/** Whether a declared route owns its `models` array in the user layer. */
+export function userOwnsModels(
+  namespace: SettingsNamespaceView,
+  path: readonly string[],
+): boolean {
+  return hasPath(namespace.user ?? {}, [...path, 'models'])
 }
 
 /** One row of the capabilities page. */
@@ -242,6 +249,8 @@ export class CapabilitiesController {
   private activeAbort: AbortController | undefined
   /** Prevent a disposed plugin fiber from receiving a late response. */
   private disposed = false
+  /** Serialize mutations so each write builds from the latest accepted namespace. */
+  private mutationTail: Promise<void> = Promise.resolve()
 
   /** Stop in-flight reads and make every later response a no-op. */
   dispose(): void {
@@ -298,7 +307,7 @@ export class CapabilitiesController {
           configured: namespace !== undefined && hasPath(namespace.value ?? {}, entry.settingsPath),
           declaredEditable: namespace !== undefined
             && entry.declared === true
-            && hasPath(namespace.user ?? {}, [...entry.settingsPath, 'models']),
+            && userOwnsModels(namespace, entry.settingsPath),
           models: namespace === undefined ? [] : profileModels(namespace, entry.settingsPath),
         }))
       this.store.setSnapshot({
@@ -307,8 +316,8 @@ export class CapabilitiesController {
         writable: settings.writable,
         namespace,
         rows: joined.filter(row => row.configured && row.entry.declared !== false),
-        levels: reasoningLevelChoices(namespace),
-        modalities: inputModalityChoices(namespace),
+        ...extractCapabilityVocabulary(namespace),
+        
       })
     } catch (error: unknown) {
       if (!this.isCurrent(generation)) return
@@ -322,29 +331,56 @@ export class CapabilitiesController {
   }
 
   /**
-   * Apply a profile write; business failures surface as thrown errors. The
-   * SERVER-ACCEPTED namespace replaces the local one immediately: its
-   * revision is the only correct CAS baseline for the next write — a
-   * background-refresh failure after a commit must never strand us on the
-   * pre-write revision (that manufactures a spurious `settings-conflict`).
+   * Build and apply a profile write from one atomic snapshot, then reload.
+   *
+   * The op builder receives the exact namespace that also supplies
+   * `expectedRevision`, closing the stale-render-closure race. Mutations are
+   * serialized so concurrent row saves build from sequentially refreshed
+   * namespaces. Returns whether a write actually landed; an empty builder is a
+   * no-op that still keeps the UI draft intact.
    */
-  async mutate(ops: SettingsPathOpView[]): Promise<SettingsNamespaceView> {
+  async commit(build: (namespace: SettingsNamespaceView) => SettingsPathOpView[]): Promise<boolean> {
+    try {
+      const wrote = await this.enqueueMutation(async (): Promise<boolean> => {
+        const namespace = this.prepareMutation()
+        const ops = build(namespace)
+        if (ops.length === 0) return false
+        const next = unwrap(await this.api.settings.mutate({
+          ns: PI_AI_NS,
+          ops,
+          expectedRevision: namespace.revision,
+        }))
+        this.store.setSnapshot({ ...this.store.getSnapshot(), namespace: next })
+        return true
+      })
+      if (wrote) await this.reload()
+      return wrote
+    } catch (caught) {
+      // Keep sibling surfaces re-anchored on any failure path.
+      await this.reload()
+      throw caught
+    }
+  }
+
+  /** Serialize one mutation step after any prior queued mutation. */
+  private enqueueMutation<T>(run: () => Promise<T>): Promise<T> {
+    const pending = this.mutationTail.then(run, run)
+    this.mutationTail = pending.then(() => undefined, () => undefined)
+    return pending
+  }
+
+  /** Fence stale reads and return the authoritative mutation namespace. */
+  private prepareMutation(): SettingsNamespaceView {
     if (this.disposed) throw new Error('better-model-provider: controller disposed')
-    // A read that started before this write may still carry the old revision.
-    // Fence it before sending the mutation so its late response cannot roll
+    // The read that started before this write may still carry the old revision.
+    // Fence it before sending the mutation so its stale response cannot roll
     // the authoritative post-write CAS baseline backwards.
     this.generation += 1
     this.activeAbort?.abort()
     this.activeAbort = undefined
     const snapshot = this.store.getSnapshot()
     if (snapshot.namespace === undefined) throw new Error('better-model-provider: settings namespace unavailable')
-    const next = unwrap(await this.api.settings.mutate({
-      ns: PI_AI_NS,
-      ops,
-      expectedRevision: snapshot.namespace.revision,
-    }))
-    this.store.setSnapshot({ ...this.store.getSnapshot(), namespace: next })
-    return next
+    return snapshot.namespace
   }
 
   /** Reload after a mutation lands (or any forwarded invalidation). */

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -340,26 +340,32 @@ export class CapabilitiesController {
    * no-op that still keeps the UI draft intact.
    */
   async commit(build: (namespace: SettingsNamespaceView) => SettingsPathOpView[]): Promise<boolean> {
-    try {
-      const wrote = await this.enqueueMutation(async (): Promise<boolean> => {
-        const namespace = this.prepareMutation()
-        const ops = build(namespace)
+    return this.enqueueMutation(async (): Promise<boolean> => {
+      try {
+        if (this.disposed) throw new Error('better-model-provider: controller disposed')
+        const current = this.store.getSnapshot().namespace
+        if (current === undefined) throw new Error('better-model-provider: settings namespace unavailable')
+        const ops = build(current)
+        // No-op commits do not establish a mutation fence: they abort no
+        // refresh and trigger no reload.
         if (ops.length === 0) return false
+        // Only a real write fences stale reads and owns the CAS baseline.
+        const namespace = this.prepareMutation()
         const next = unwrap(await this.api.settings.mutate({
           ns: PI_AI_NS,
           ops,
           expectedRevision: namespace.revision,
         }))
         this.store.setSnapshot({ ...this.store.getSnapshot(), namespace: next })
+        await this.reload()
         return true
-      })
-      if (wrote) await this.reload()
-      return wrote
-    } catch (caught) {
-      // Keep sibling surfaces re-anchored on any failure path.
-      await this.reload()
-      throw caught
-    }
+      } catch (caught) {
+        // Recovery is part of the serialized transaction: the next queued
+        // commit must build from the refreshed namespace, not the stale one.
+        await this.reload()
+        throw caught
+      }
+    })
   }
 
   /** Serialize one mutation step after any prior queued mutation. */
@@ -371,16 +377,12 @@ export class CapabilitiesController {
 
   /** Fence stale reads and return the authoritative mutation namespace. */
   private prepareMutation(): SettingsNamespaceView {
-    if (this.disposed) throw new Error('better-model-provider: controller disposed')
-    // The read that started before this write may still carry the old revision.
-    // Fence it before sending the mutation so its stale response cannot roll
-    // the authoritative post-write CAS baseline backwards.
+    // commit() has already validated liveness and the namespace before it
+    // reaches here; this step only fences reads that started before the write.
     this.generation += 1
     this.activeAbort?.abort()
     this.activeAbort = undefined
-    const snapshot = this.store.getSnapshot()
-    if (snapshot.namespace === undefined) throw new Error('better-model-provider: settings namespace unavailable')
-    return snapshot.namespace
+    return this.store.getSnapshot().namespace as SettingsNamespaceView
   }
 
   /** Reload after a mutation lands (or any forwarded invalidation). */

--- a/src/client/writes.ts
+++ b/src/client/writes.ts
@@ -9,7 +9,9 @@
  */
 
 import type { SettingsNamespaceView, SettingsPathOpView } from './types.ts'
-import { profileModels } from './store.ts'
+import { profileModels, userOwnsModels } from './store.ts'
+import type { ReasoningEffortsValue } from './store.ts'
+import { parseCapacity } from './capacity.ts'
 
 /** The full staged capability state of one model row. */
 export interface CapabilityState {
@@ -31,8 +33,56 @@ export interface CapabilityPatch {
   maxTokens?: { value: CapabilityState['maxTokens'] }
 }
 
+/** Staged partial state of one row: null means untouched. */
+export interface RowDraft {
+  /** The row edited reasoning (`undefined` staged means "inherit"). */
+  reasoningTouched: boolean
+  /** Staged reasoning-effort declaration. */
+  reasoning?: ReasoningEffortsValue | undefined
+  /** The row edited input (`undefined` staged means "inherit"). */
+  inputTouched: boolean
+  /** Staged input modalities. */
+  input?: readonly unknown[] | undefined
+  /** The row edited either capacity field (blank text means "inherit"). */
+  capacityTouched: boolean
+  /** Staged `contextWindow` text (K/M spellings; parsed on use). */
+  contextWindowText: string
+  /** Staged `maxTokens` text (K/M spellings; parsed on use). */
+  maxTokensText: string
+}
+
+/** Build the row's whole state: stored entry overlaid with the draft. */
+export function rowStateOf(entry: Record<string, unknown>, draft: RowDraft | null): CapabilityState {
+  return {
+    reasoning: draft?.reasoningTouched === true
+      ? draft.reasoning
+      : entry['reasoningEfforts'] as ReasoningEffortsValue,
+    input: draft?.inputTouched === true
+      ? draft.input
+      : entry['input'] as readonly unknown[] | undefined,
+    contextWindow: draft?.capacityTouched === true
+      ? parseCapacity(draft.contextWindowText)
+      : entry['contextWindow'] as number | undefined,
+    maxTokens: draft?.capacityTouched === true
+      ? parseCapacity(draft.maxTokensText)
+      : entry['maxTokens'] as number | undefined,
+  }
+}
+
+/** Convert the row's touched flags into a patch that preserves inheritance. */
+export function patchOf(state: CapabilityState, draft: RowDraft): CapabilityPatch {
+  const patch: CapabilityPatch = {}
+  if (draft.reasoningTouched) patch.reasoning = { value: state.reasoning }
+  if (draft.inputTouched) patch.input = { value: state.input }
+  if (draft.capacityTouched) {
+    patch.contextWindow = { value: state.contextWindow }
+    patch.maxTokens = { value: state.maxTokens }
+  }
+  return patch
+}
+
 /**
- * Whether the staged state differs from what the entry stores today, so a
+ * Whether the staged state differs from what a row stores today, so a
  * row with no real change writes nothing.
  */
 export function stagedDiffers(entry: Record<string, unknown>, state: CapabilityState): boolean {
@@ -85,7 +135,7 @@ export function declaredEditOps(
   patch: CapabilityPatch,
 ): SettingsPathOpView[] {
   const models = profileModels(namespace, path, 'user')
-  if (index < 0 || index >= models.length) return []
+  if (!userOwnsModels(namespace, path) || index < 0 || index >= models.length) return []
   const nextModels = models.map((entry, i) => (i === index ? applyPatch(entry, patch) : { ...entry }))
   return [{ op: 'set', path: [...path, 'models'], value: nextModels }]
 }

--- a/src/client/writes.ts
+++ b/src/client/writes.ts
@@ -10,8 +10,6 @@
 
 import type { SettingsNamespaceView, SettingsPathOpView } from './types.ts'
 import { profileModels, userOwnsModels } from './store.ts'
-import type { ReasoningEffortsValue } from './store.ts'
-import { parseCapacity } from './capacity.ts'
 
 /** The full staged capability state of one model row. */
 export interface CapabilityState {
@@ -33,53 +31,7 @@ export interface CapabilityPatch {
   maxTokens?: { value: CapabilityState['maxTokens'] }
 }
 
-/** Staged partial state of one row: null means untouched. */
-export interface RowDraft {
-  /** The row edited reasoning (`undefined` staged means "inherit"). */
-  reasoningTouched: boolean
-  /** Staged reasoning-effort declaration. */
-  reasoning?: ReasoningEffortsValue | undefined
-  /** The row edited input (`undefined` staged means "inherit"). */
-  inputTouched: boolean
-  /** Staged input modalities. */
-  input?: readonly unknown[] | undefined
-  /** The row edited either capacity field (blank text means "inherit"). */
-  capacityTouched: boolean
-  /** Staged `contextWindow` text (K/M spellings; parsed on use). */
-  contextWindowText: string
-  /** Staged `maxTokens` text (K/M spellings; parsed on use). */
-  maxTokensText: string
-}
 
-/** Build the row's whole state: stored entry overlaid with the draft. */
-export function rowStateOf(entry: Record<string, unknown>, draft: RowDraft | null): CapabilityState {
-  return {
-    reasoning: draft?.reasoningTouched === true
-      ? draft.reasoning
-      : entry['reasoningEfforts'] as ReasoningEffortsValue,
-    input: draft?.inputTouched === true
-      ? draft.input
-      : entry['input'] as readonly unknown[] | undefined,
-    contextWindow: draft?.capacityTouched === true
-      ? parseCapacity(draft.contextWindowText)
-      : entry['contextWindow'] as number | undefined,
-    maxTokens: draft?.capacityTouched === true
-      ? parseCapacity(draft.maxTokensText)
-      : entry['maxTokens'] as number | undefined,
-  }
-}
-
-/** Convert the row's touched flags into a patch that preserves inheritance. */
-export function patchOf(state: CapabilityState, draft: RowDraft): CapabilityPatch {
-  const patch: CapabilityPatch = {}
-  if (draft.reasoningTouched) patch.reasoning = { value: state.reasoning }
-  if (draft.inputTouched) patch.input = { value: state.input }
-  if (draft.capacityTouched) {
-    patch.contextWindow = { value: state.contextWindow }
-    patch.maxTokens = { value: state.maxTokens }
-  }
-  return patch
-}
 
 /**
  * Whether the staged state differs from what a row stores today, so a

--- a/tests/section.client.spec.tsx
+++ b/tests/section.client.spec.tsx
@@ -162,7 +162,27 @@ describe('declared-route capability editing', () => {
     expect(inputSelect().value).toBe('')
   })
 
-  test('revert discards the staged state', async () => {
+  test('selecting inherit from custom input clears all modalities', async () => {
+      await mount()
+      await expandFirstModel()
+      fireEvent.change(inputSelect(), { target: { value: 'custom' } })
+      expect(inputSelect().value).toBe('custom')
+      fireEvent.change(inputSelect(), { target: { value: '' } })
+      expect(inputSelect().value).toBe('')
+    })
+
+    test('a stored non-string wire renders as an empty wire field', async () => {
+      const arrange = defaultArrangement()
+      arrange.user = { providers: { ksyun: { models: [{ id: 'Kimi-K3', name: 'Kimi', reasoningEfforts: { minimal: 123 } }] } } }
+      arrange.value = arrange.user
+      await mount(arrange)
+      await expandFirstModel()
+      fireEvent.click(screen.getByRole('button', { name: /selected/ }))
+      const wire = getByLabelText(document.body, 'minimal wire') as HTMLInputElement
+      expect(wire.value).toBe('')
+    })
+
+    test('revert discards the staged state', async () => {
     await mount()
     await expandFirstModel()
     fireEvent.change(reasoningSelect(), { target: { value: 'off' } })
@@ -201,8 +221,10 @@ describe('declared-route capability editing', () => {
     expect(document.querySelector('.bmp-msPanel')).not.toBeNull()
     fireEvent.mouseDown(document.body)
     expect(document.querySelector('.bmp-msPanel')).toBeNull()
-    // Reopen once more: Escape dismisses.
+    // Reopen once more: non-Escape keys do not dismiss, Escape does.
     fireEvent.click(picker)
+    expect(document.querySelector('.bmp-msPanel')).not.toBeNull()
+    fireEvent.keyDown(document.body, { key: 'Enter' })
     expect(document.querySelector('.bmp-msPanel')).not.toBeNull()
     fireEvent.keyDown(document.body, { key: 'Escape' })
     expect(document.querySelector('.bmp-msPanel')).toBeNull()
@@ -233,7 +255,17 @@ describe('declared-route capability editing', () => {
     expect(screen.queryByRole('alert')?.textContent).toBe('nope')
   })
 
-  test('an input-only edit does not unset reasoning or copy other fields', async () => {
+  test('a no-op commit keeps the staged draft visible', async () => {
+      const { controller } = await mount()
+      controller.commit = async () => false
+      await expandFirstModel()
+      fireEvent.change(reasoningSelect(), { target: { value: 'off' } })
+      await waitFor(() => expect(screen.queryByText(en.staged)).not.toBeNull())
+      fireEvent.click(screen.getByRole('button', { name: en.apply }))
+      await waitFor(() => expect(screen.queryByText(en.staged)).not.toBeNull())
+    })
+
+    test('an input-only edit does not unset reasoning or copy other fields', async () => {
     const { mutates } = await mount()
     await expandFirstModel()
     fireEvent.change(inputSelect(), { target: { value: 'custom' } })

--- a/tests/store.client.spec.ts
+++ b/tests/store.client.spec.ts
@@ -6,8 +6,8 @@
 
 import { describe, expect, test } from 'vitest'
 import {
-  CapabilitiesController, createSnapshotStore, inputModalityChoices, messageOf, profileModels,
-  reasoningLevelChoices, validInputModalities, validReasoningEfforts,
+  CapabilitiesController, createSnapshotStore, extractCapabilityVocabulary, messageOf, profileModels,
+  validInputModalities, validReasoningEfforts,
 } from '../src/client/store.ts'
 import type { SettingsNamespaceView } from '../src/client/types.ts'
 import { assertEmptyPayload, defaultArrangement, envelopeError, envelopeOk, modelsEnvelope, piAiNamespace, scriptedFace } from './helpers.ts'
@@ -16,11 +16,11 @@ describe('vocabulary from the serialized schema', () => {
   const ns = piAiNamespace(defaultArrangement())
 
   test('reasoning levels follow the schema order', () => {
-    expect(reasoningLevelChoices(ns)).toEqual(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+    expect(extractCapabilityVocabulary(ns).levels).toEqual(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
   })
 
   test('input modalities follow the schema order', () => {
-    expect(inputModalityChoices(ns)).toEqual(['text', 'image'])
+    expect(extractCapabilityVocabulary(ns).modalities).toEqual(['text', 'image'])
   })
 
   const bareNs = (schema: unknown): SettingsNamespaceView =>
@@ -34,14 +34,14 @@ describe('vocabulary from the serialized schema', () => {
     ['schema not an object', bareNs('not-an-envelope'), []],
     ['malformed envelope rehydrate throws', bareNs(null), []],
   ])('%s yields an empty vocabulary', (_label, namespace, expected) => {
-    expect(reasoningLevelChoices(namespace as SettingsNamespaceView)).toEqual(expected)
-    expect(inputModalityChoices(namespace as SettingsNamespaceView)).toEqual(expected)
+    expect(extractCapabilityVocabulary(namespace as SettingsNamespaceView).levels).toEqual(expected)
+    expect(extractCapabilityVocabulary(namespace as SettingsNamespaceView).modalities).toEqual(expected)
   })
 
   test('a models item without the fields yields nothing', () => {
     const bare = bareNs(modelsEnvelope({ type: 'array', inner: { type: 'object', dict: { id: { type: 'string' } } } }))
-    expect(reasoningLevelChoices(bare)).toEqual([])
-    expect(inputModalityChoices(bare)).toEqual([])
+    expect(extractCapabilityVocabulary(bare).levels).toEqual([])
+    expect(extractCapabilityVocabulary(bare).modalities).toEqual([])
   })
 
   test('a dict key union without a list or with non-strings yields only strings', () => {
@@ -58,8 +58,8 @@ describe('vocabulary from the serialized schema', () => {
         },
       },
     }))
-    expect(reasoningLevelChoices(shaped)).toEqual(['good'])
-    expect(inputModalityChoices(shaped)).toEqual([])
+    expect(extractCapabilityVocabulary(shaped).levels).toEqual(['good'])
+    expect(extractCapabilityVocabulary(shaped).modalities).toEqual([])
 
     const keyless = bareNs(modelsEnvelope({
       type: 'array',
@@ -73,7 +73,7 @@ describe('vocabulary from the serialized schema', () => {
         },
       },
     }))
-    expect(reasoningLevelChoices(keyless)).toEqual([])
+    expect(extractCapabilityVocabulary(keyless).levels).toEqual([])
   })
 
   test('a reasoningEfforts schema without the dict member yields nothing', () => {
@@ -81,8 +81,8 @@ describe('vocabulary from the serialized schema', () => {
       type: 'array',
       inner: { type: 'object', dict: { reasoningEfforts: { type: 'boolean' }, input: { type: 'array', inner: { type: 'string' } } } },
     }))
-    expect(reasoningLevelChoices(without)).toEqual([])
-    expect(inputModalityChoices(without)).toEqual([])
+    expect(extractCapabilityVocabulary(without).levels).toEqual([])
+    expect(extractCapabilityVocabulary(without).modalities).toEqual([])
   })
 })
 
@@ -185,7 +185,7 @@ describe('controller join', () => {
     expect(snapshot.rows[0]?.models).toEqual([{ id: 'Kimi-K3', name: 'Kimi' }])
     expect(snapshot.levels).toHaveLength(7)
     expect(snapshot.modalities).toEqual(['text', 'image'])
-    await controller.mutate([{ op: 'set', path: ['providers', 'x'], value: {} }])
+    await controller.commit(() => [{ op: 'set', path: ['providers', 'x'], value: {} }])
   })
 
   test('missing namespace leaves rows joined from an empty profile', async () => {
@@ -219,7 +219,7 @@ describe('controller join', () => {
     const arrange = defaultArrangement()
     const { api } = scriptedFace(arrange)
     const controller = new CapabilitiesController(api)
-    await expect(controller.mutate([])).rejects.toThrow('namespace unavailable')
+    await expect(controller.commit(() => [])).rejects.toThrow('namespace unavailable')
   })
 
   test('setting the identical snapshot publishes nothing', () => {
@@ -261,7 +261,7 @@ describe('controller join', () => {
     api.settings.mutate = () => Promise.resolve(envelopeError('settings-conflict', 'moved on'))
     const controller = new CapabilitiesController(api)
     await controller.load()
-    await expect(controller.mutate([])).rejects.toMatchObject({ code: 'settings-conflict', name: 'HarnessRpcError' })
+    await expect(controller.commit(() => [{ op: 'set', path: ['providers', 'x'], value: {} }])).rejects.toMatchObject({ code: 'settings-conflict', name: 'HarnessRpcError' })
   })
 
   test('business failures on mutate throw the error message', async () => {
@@ -270,7 +270,7 @@ describe('controller join', () => {
     const controller = new CapabilitiesController(api)
     await controller.load()
     api.settings.mutate = () => Promise.resolve(envelopeError('settings-conflict', 'revision moved'))
-    await expect(controller.mutate([])).rejects.toThrow('revision moved')
+    await expect(controller.commit(() => [{ op: 'set', path: ['providers', 'x'], value: {} }])).rejects.toThrow('revision moved')
   })
 
   test('a mutation fences an in-flight refresh before advancing the CAS baseline', async () => {
@@ -282,15 +282,17 @@ describe('controller join', () => {
     const originalDescribe = api.settings.describe
     let release!: (value: Awaited<ReturnType<typeof originalDescribe>>) => void
     const slow = new Promise<Awaited<ReturnType<typeof originalDescribe>>>(resolve => { release = resolve })
+    let describeCalls = 0
     api.settings.describe = payload => {
+      describeCalls += 1
       assertEmptyPayload('settings.describe', payload)
-      return slow
+      return describeCalls === 1 ? slow : originalDescribe(payload)
     }
     const staleNamespace = piAiNamespace(arrange)
     const refresh = controller.reload()
     await Promise.resolve()
 
-    await controller.mutate([{
+    await controller.commit(() => [{
       op: 'set',
       path: ['providers', 'ksyun', 'models'],
       value: [{ id: 'Kimi-K3', reasoningEfforts: false }],
@@ -357,7 +359,7 @@ describe('controller join', () => {
     await controller.load()
     // Commit once: the server view lands with revision 2 and must become the
     // new baseline immediately.
-    await controller.mutate([{ op: 'set', path: ['providers', 'ksyun'], value: {} }])
+    await controller.commit(() => [{ op: 'set', path: ['providers', 'ksyun'], value: {} }])
     expect(mutates[0]?.expectedRevision).toBe(1)
     // Now the background refresh fails: the revision must still have advanced.
     api.settings.describe = payload => {
@@ -367,7 +369,7 @@ describe('controller join', () => {
     await controller.reload()
     expect(controller.store.getSnapshot().namespace?.revision).toBe(2)
     // The next write CASes against the committed revision, not the pre-write one.
-    await controller.mutate([{ op: 'set', path: ['providers', 'ksyun'], value: {} }])
+    await controller.commit(() => [{ op: 'set', path: ['providers', 'ksyun'], value: {} }])
     expect(mutates[1]?.expectedRevision).toBe(2)
   })
 
@@ -435,7 +437,7 @@ describe('controller join', () => {
     await pending
     expect(controller.store.getSnapshot().status).toBe('loading')
     expect(controller.store.getSnapshot().rows).toEqual([])
-    await expect(controller.mutate([])).rejects.toThrow('controller disposed')
+    await expect(controller.commit(() => [])).rejects.toThrow('controller disposed')
     await expect(controller.load()).resolves.toBeUndefined()
   })
 
@@ -447,5 +449,44 @@ describe('controller join', () => {
     arrange.providers = []
     await controller.reload()
     expect(controller.store.getSnapshot().rows).toEqual([])
+  })
+
+  test('commit returns false for empty ops without writing or reloading', async () => {
+    const arrange = defaultArrangement()
+    const { api, mutates } = scriptedFace(arrange)
+    const controller = new CapabilitiesController(api)
+    await controller.load()
+
+    let describes = 0
+    const before = api.settings.describe
+    api.settings.describe = payload => {
+      describes += 1
+      return before(payload)
+    }
+    await expect(controller.commit(() => [])).resolves.toBe(false)
+    expect(mutates).toEqual([])
+    expect(describes).toBe(0)
+  })
+
+  test('commit writes, updates the baseline, and reloads', async () => {
+    const arrange = defaultArrangement()
+    const { api, mutates } = scriptedFace(arrange)
+    const controller = new CapabilitiesController(api)
+    await controller.load()
+
+    let describes = 0
+    const before = api.settings.describe
+    api.settings.describe = payload => {
+      describes += 1
+      return before(payload)
+    }
+    await expect(controller.commit(() => [{
+      op: 'set',
+      path: ['providers', 'x'],
+      value: { committed: true },
+    }])).resolves.toBe(true)
+    expect(mutates).toHaveLength(1)
+    expect(mutates[0]?.expectedRevision).toBe(1)
+    expect(describes).toBe(1)
   })
 })

--- a/tests/store.client.spec.ts
+++ b/tests/store.client.spec.ts
@@ -489,4 +489,54 @@ describe('controller join', () => {
     expect(mutates[0]?.expectedRevision).toBe(1)
     expect(describes).toBe(1)
   })
+
+  test('concurrent commits serialize success: the second builder sees the first accepted namespace', async () => {
+    const arrange = defaultArrangement()
+    const { api, mutates } = scriptedFace(arrange)
+    const controller = new CapabilitiesController(api)
+    await controller.load()
+
+    const seen: number[] = []
+    const first = controller.commit(() => {
+      seen.push(controller.store.getSnapshot().namespace?.revision ?? 0)
+      return [{ op: 'set', path: ['providers', 'first'], value: {} }]
+    })
+    const second = controller.commit(() => {
+      seen.push(controller.store.getSnapshot().namespace?.revision ?? 0)
+      return [{ op: 'set', path: ['providers', 'second'], value: {} }]
+    })
+    await Promise.all([first, second])
+
+    expect(seen).toEqual([1, 2])
+    expect(mutates).toHaveLength(2)
+    expect(mutates[0]?.expectedRevision).toBe(1)
+    expect(mutates[1]?.expectedRevision).toBe(2)
+  })
+
+  test('concurrent commits serialize recovery: the second builder sees the post-reload namespace', async () => {
+    const arrange = defaultArrangement()
+    const { api, mutates } = scriptedFace(arrange)
+    const controller = new CapabilitiesController(api)
+    await controller.load()
+
+    // Simulate an external revision advancing between the request load and A.
+    arrange.revision = 2
+    const seen: number[] = []
+    const first = controller.commit(() => {
+      seen.push(controller.store.getSnapshot().namespace?.revision ?? 0)
+      return [{ op: 'set', path: ['providers', 'first'], value: {} }]
+    })
+    const second = controller.commit(() => {
+      seen.push(controller.store.getSnapshot().namespace?.revision ?? 0)
+      return [{ op: 'set', path: ['providers', 'second'], value: {} }]
+    })
+
+    await expect(first).rejects.toMatchObject({ code: 'settings-conflict', name: 'HarnessRpcError' })
+    await expect(second).resolves.toBe(true)
+
+    expect(seen).toEqual([1, 2])
+    expect(mutates).toHaveLength(2)
+    expect(mutates[0]?.expectedRevision).toBe(1)
+    expect(mutates[1]?.expectedRevision).toBe(2)
+  })
 })


### PR DESCRIPTION
## Summary

This PR adapts the context-governor optimization onto the current public main.

- `extractCapabilityVocabulary()` replaces separate reasoning/input readers
- `userOwnsModels` centralizes user-layer models ownership
- `commit(builder)` becomes the single write transaction, returns boolean for no-op, owns reload
- capacity (`contextWindow` / `maxTokens`) support is preserved

## Review follow-ups

- `RowDraft` / `rowStateOf` / `patchOf` stay in `CapabilitiesSection.tsx`; `writes.ts` remains pure patch → `settings.mutate` path-op builders.
- `commit()` now serializes the whole transaction including success/failure reload.
- No-op commits return `false` without aborting in-flight reads or issuing reload.
- Added concurrent-commit tests for both success and conflict/recovery ordering.

## Verification

- tests: 157 passed / 3 skipped
- coverage: 100% per-file
- typecheck / lint / build / verify-pack all pass

## Commits

1. docs: keep context-governor seed out of the project tree
2. refactor(client): consolidate vocabulary, row writes, and commit transaction
3. test(client): cover vocabulary, commit transaction, and no-op semantics
4. test(client): cover no-op commits and remaining UI branches
5. refactor(client): keep row draft state local to the capabilities section
6. fix(store): serialize reload and avoid aborting reads on no-op commits
7. test(store): cover serialized success and recovery for concurrent commits
